### PR TITLE
Autopep

### DIFF
--- a/python/DataCatalog.py
+++ b/python/DataCatalog.py
@@ -1,3 +1,4 @@
+# flake8: noqa
 """
 Use Brian's python client to query the SRS datacatalog.
 """

--- a/python/exploreRaft.py
+++ b/python/exploreRaft.py
@@ -32,7 +32,7 @@ class exploreRaft():
             if '13574' in kid:
                 reb_list.append((kid, row['slotName']))
 
-# match up the CCD to the REB via REB and slot numbering. The CCD in slot 
+# match up the CCD to the REB via REB and slot numbering. The CCD in slot
 # Sxy is on REBx. Note that the CCD is actually
 # assembled onto the RSA.
 

--- a/python/findCCD.py
+++ b/python/findCCD.py
@@ -1,5 +1,5 @@
 import argparse
-from DataCatalog import *
+from DataCatalog import DataCatalog
 # import subprocess
 # import shlex
 import os

--- a/python/findCCD.py
+++ b/python/findCCD.py
@@ -9,7 +9,7 @@ from eTraveler.clientAPI.connection import Connection
 class findCCD():
 
     def __init__(self, mirrorName='BNL-prod', FType=None, XtraOpts=None,
-                 testName=None, sensorId=None, run=None, outputFile=None, 
+                 testName=None, sensorId=None, run=None, outputFile=None,
                  site='slac.lca.archive', Print=False, db='Prod',
                  prodServer='Dev', appSuffix='-jrb'):
 
@@ -51,21 +51,29 @@ class findCCD():
             appSuffix=appSuffix)
 
     def find(self, mirrorName=None, FType=None, XtraOpts=None,
-                 testName=None, sensorId=None, run=None, outputFile=None, 
-                 site=None, Print=None):
+             testName=None, sensorId=None, run=None, outputFile=None,
+             site=None, Print=None):
 
-        if mirrorName is not None: self.mirrorName = mirrorName
-        if FType is not None: self.FType = FType
-        if XtraOpts is not None: self.XtraOpts = XtraOpts
-        if testName is not None: self.testName = testName
+        if mirrorName is not None:
+            self.mirrorName = mirrorName
+        if FType is not None:
+            self.FType = FType
+        if XtraOpts is not None:
+            self.XtraOpts = XtraOpts
+        if testName is not None:
+            self.testName = testName
 
-        if sensorId is not None: self.sensorId = sensorId
-        if outputFile is not None: self.outputFile = outputFile
-        if site is not None: self.site = site
-        if Print is not None: self.Print = Print
-        if run is not None: self.run = run
+        if sensorId is not None:
+            self.sensorId = sensorId
+        if outputFile is not None:
+            self.outputFile = outputFile
+        if site is not None:
+            self.site = site
+        if Print is not None:
+            self.Print = Print
+        if run is not None:
+            self.run = run
 
-        
         sourceMap = {
             'BNL-prod': 'BNL-prod/prod/',
             'BNL-test': 'BNL-test/test/',
@@ -169,7 +177,8 @@ if __name__ == "__main__":
 
         # Command line arguments
     parser = argparse.ArgumentParser(
-        description='Find archived data in the LSST  data Catalog. These include CCD test stand and vendor data files.')
+        description='Find archived data in the LSST  data Catalog. '
+                    'These include CCD test stand and vendor data files.')
 
     # The following are 'convenience options' which could also be specified in
     # the filter string

--- a/python/merge_over.py
+++ b/python/merge_over.py
@@ -64,10 +64,8 @@ for infile in infiles:
             ccdpx, ccdpy = ccdax + 193, ccday + 104
             gap_inx, gap_iny = 28, 25
             gap_outx, gap_outy = 26.5, 25
-            crval1q = gap_outy + (ccdpy - ccday) / 2 + Cs * (8 * dimh + gap_iny +
-                                                             ccdpy - ccday) + Sp * (dimh + 1) + Ss * dimh + (2 * Sp - 1) * preh
-            crval2q = Sp * (2 * dimv + 1) + gap_outx + (ccdpx - ccdax) / 2 + Cp * (2 *
-                                                                                   dimv + gap_inx + ccdpx - ccdax)
+            crval1q = gap_outy + (ccdpy - ccday) / 2 + Cs * (8 * dimh + gap_iny + ccdpy - ccday) + Sp * (dimh + 1) + Ss * dimh + (2 * Sp - 1) * preh # noqa
+            crval2q = Sp * (2 * dimv + 1) + gap_outx + (ccdpx - ccdax) / 2 + Cp * (2 * dimv + gap_inx + ccdpx - ccdax) # noqa
         else:
             dsx1 = (Sy + 1) * dimh
             dsx2 = Sy * dimh + 1

--- a/python/raft_observation.py
+++ b/python/raft_observation.py
@@ -7,7 +7,7 @@ import os
 class raft_observation():
 
     def __init__(self, run=None, step=None, imgtype=None,
-                 db='Prod', prodServer='Dev', appSuffix='-jrb', site ='slac.lca.archive'):
+                 db='Prod', prodServer='Dev', appSuffix='-jrb', site='slac.lca.archive'):
 
         chk_list = (run, step)
 
@@ -15,7 +15,6 @@ class raft_observation():
             print 'Error: missing input to raft_observation'
             raise ValueError
 
-        
         if prodServer == 'Prod':
             pS = True
         else:
@@ -39,12 +38,14 @@ class raft_observation():
         self.step = step
         self.imgtype = imgtype
 
-
     def find(self, run=None, step=None, imgtype=None):
 
-        if run is not None: self.run = run
-        if step is not None: self.step = step
-        if imgtype is not None: self.imgtype = imgtype
+        if run is not None:
+            self.run = run
+        if step is not None:
+            self.step = step
+        if imgtype is not None:
+            self.imgtype = imgtype
 
         rsp = self.connect.getRunSummary(run=self.run)
         raft = rsp['experimentSN']
@@ -66,12 +67,12 @@ class raft_observation():
                 sensorId=ccd,
                 run=str(
                     self.run),
-                db = self.db,
-                prodServer = self.prodServer,
-                appSuffix = self.appSuffix,
+                db=self.db,
+                prodServer=self.prodServer,
+                appSuffix=self.appSuffix,
                 site=self.site,
-                XtraOpts = XtraOpts
-                )
+                XtraOpts=XtraOpts
+            )
             files = self.fCCD.find()
 
             for f in files:
@@ -86,7 +87,14 @@ class raft_observation():
 
 if __name__ == "__main__":
 
-    rO = raft_observation(run=4963, step='fe55_raft_acq', imgtype="BIAS", db='Dev', site='BNL',prodServer='Dev', appSuffix='-jrb')
+    rO = raft_observation(
+        run=4963,
+        step='fe55_raft_acq',
+        imgtype="BIAS",
+        db='Dev',
+        site='BNL',
+        prodServer='Dev',
+        appSuffix='-jrb')
 
     obs_dict = rO.find()
     print obs_dict


### PR DESCRIPTION
completed a round of autopep8 runs with more aggressive flags passed
`autopep8 --in-place --recursive --ignore E133,E226,E228,E251,N802,N803 --max-line-length 110 -a -a -a .`
For now the # noqa flag has been set for the DataCatalog.py script and two lines within merge_over.py
All scripts have been tested after the modifications have been made.