### PR TITLE
get_EO_analysis_files: require ccd name in file spec

### DIFF
--- a/python/dev_prod_eT.py
+++ b/python/dev_prod_eT.py
@@ -1,0 +1,62 @@
+from __future__ import print_function
+
+from exploreFocalPlane import exploreFocalPlane
+from exploreRaft import exploreRaft
+from exploreRun import exploreRun
+from findCCD import findCCD
+from eTraveler.clientAPI.connection import Connection
+
+"""
+Helper tool to ease use of dev vs prod eTraveler databases.
+
+Usage:
+
+from dev_prod_eT import dev_prod_eT
+
+t = dev_prod_eT()
+
+t.add_app("Connection")
+
+run = 10517
+prod_eT = t.use_app("Connection", "Prod")
+
+"""
+
+
+class dev_prod_eT():
+
+    def __init__(self):
+
+        self.app_map = {}
+
+    def add_app(self, app_name=None):
+
+        a = self.app_map.setdefault(app_name, {})
+
+        mod = globals()[app_name]
+        kwargs = {"db": "Prod"}
+        if app_name == "Connection":
+            kwargs["operator"] = "richard"
+        elif app_name == "findCCD":
+            kwargs["run"] = 0
+            kwargs["sensorId"] = ""
+            kwargs["testName"] = ""
+            kwargs["mirrorName"] = ""
+
+        self.app_map[app_name]["Prod"] = mod(**kwargs)
+
+        kwargs["db"] = "Dev"
+        self.app_map[app_name]["Dev"] = mod(**kwargs)
+
+    def use_app(self, app_name=None, mode=None):
+
+        return self.app_map[app_name][mode]
+
+    def set_db(self, run=None):
+
+        db = "Prod"
+        if type(run) == str:
+            if "D" in run.upper():
+                db = "Dev"
+
+        return db

--- a/python/dev_prod_eT.py
+++ b/python/dev_prod_eT.py
@@ -31,7 +31,7 @@ class dev_prod_eT():
 
     def add_app(self, app_name=None):
 
-        a = self.app_map.setdefault(app_name, {})
+        self.app_map.setdefault(app_name, {})
 
         mod = globals()[app_name]
         kwargs = {"db": "Prod"}

--- a/python/exploreFocalPlane.py
+++ b/python/exploreFocalPlane.py
@@ -7,6 +7,10 @@ class exploreFocalPlane:
 
     def __init__(self, db='Prod', prodServer='Prod', appSuffix=''):
 
+        self.SR_htype = "LCA-11021_RTM"
+        self.CR_htype = "LCA-10692_CRTM"
+        self.raft_types = [self.SR_htype, self.CR_htype]
+
         if prodServer == 'Prod':
             pS = True
         else:
@@ -36,7 +40,7 @@ class exploreFocalPlane:
         for ind in response:
             raft = ind['child_experimentSN']
             # ignore mechanical rafts
-            if 'MTR' in raft or ind["child_hardwareTypeName"] != "LCA-11021_RTM":
+            if 'MTR' in raft or ind["child_hardwareTypeName"] not in self.raft_types:
                 continue
             slot = ind['slotName']
             # kludge for first cryo definition with slot names as BayXY, not RXY

--- a/python/findCCD.py
+++ b/python/findCCD.py
@@ -112,7 +112,10 @@ class findCCD():
         folderList = []
 
         if use_query_eT is True:
-            kwds = {'run': self.run, 'stepName': self.testName}
+            run_str = self.run
+            if type(run_str) != str:
+                run_str = str(self.run)
+            kwds = {'run': run_str, 'stepName': self.testName}
             filePaths = self.connect.getRunFilepaths(**kwds)
             # get the unique directory paths
 

--- a/python/get_EO_analysis_files.py
+++ b/python/get_EO_analysis_files.py
@@ -125,9 +125,10 @@ class get_EO_analysis_files():
                 matchlist = []
                 for f in filelist:
                     if matchstr is not None:
-                        if f.find(matchstr) < 0 or f.find(ccd[0]) < 0:
+                        if f.find(matchstr) < 0:
                             continue
-                    matchlist.append(f)
+                    if f.find(ccd[0]) >= 0:
+                        matchlist.append(f)
                 ccd_dict[ccd[idx]] = matchlist
             return ccd_dict
 

--- a/python/get_EO_analysis_files.py
+++ b/python/get_EO_analysis_files.py
@@ -120,8 +120,8 @@ class get_EO_analysis_files():
 
             for ccd in dev_list:
                 filelist = self.dev_prod.app_map["findCCD"][db].find(mirrorName=mirrorName, FType=FType,
-                                          XtraOpts=imgtype, run=run,
-                                          testName=testName, sensorId=ccd[0])
+                                                                     XtraOpts=imgtype, run=run,
+                                                                     testName=testName, sensorId=ccd[0])
                 matchlist = []
                 for f in filelist:
                     if matchstr is not None:

--- a/python/get_EO_analysis_files.py
+++ b/python/get_EO_analysis_files.py
@@ -4,6 +4,8 @@ from findCCD import findCCD
 from findFullFocalPlane import findFullFocalPlane
 from exploreRaft import exploreRaft
 from exploreFocalPlane import exploreFocalPlane
+from dev_prod_eT import dev_prod_eT
+
 import argparse
 
 """Helper tools to fetch Camera EO Test image files."""
@@ -41,16 +43,12 @@ class get_EO_analysis_files():
         self.db = db
         self.ccd_slots = ["S00", "S01", "S02", "S10", "S11", "S12", "S20", "S21", "S22"]
 
-        if server == 'Prod':
-            pS = True
-        else:
-            pS = False
-        self.connect = Connection(operator='richard', db=db, exp='LSST-CAMERA', prodServer=pS)
+        self.dev_prod = dev_prod_eT()
 
-        self.eFP = exploreFocalPlane(db=db, prodServer=server)
-        self.eR = exploreRaft(db=db, prodServer=server)
-        self.fCCD = findCCD(db=db, prodServer=server, mirrorName="", testName="", run=0, sensorId="")
-        self.f_FP = findFullFocalPlane(prodServer=server)
+        self.dev_prod.add_app("exploreFocalPlane")
+        self.dev_prod.add_app("exploreRaft")
+        self.dev_prod.add_app("Connection")
+        self.dev_prod.add_app("findCCD")
 
     def get_files(self, FType=None, testName=None, run=None, imgtype=None, matchstr=None):
         """
@@ -68,8 +66,10 @@ class get_EO_analysis_files():
             ccd_dict: dictionary of lists of files  keyed on slot or CCD name
             or raft_dict : dict by raft of dict of list of files, both keyed on slot names
         """
-        data = self.connect.getRunResults(run=run, stepName=testName)
-        self.run_sum = self.connect.getRunSummary(run=run)
+        db = self.dev_prod.set_db(run=run)
+
+        data = self.dev_prod.app_map["Connection"][db].getRunResults(run=run, stepName=testName)
+        self.run_sum = self.dev_prod.app_map["Connection"][db].getRunSummary(run=run)
         when = self.run_sum['begin']
 
         mirrorName = self.deduce_mirror(run=run)
@@ -90,7 +90,7 @@ class get_EO_analysis_files():
 
         if 'CRYO' in device.upper():
 
-            files = self.f_FP.find(run=run, testName=testName, FType=FType)
+            files = self.dev_prod.app_map["findFocalPlane"][db].find(run=run, testName=testName, FType=FType)
 
             for f in files:
                 if matchstr is not None:
@@ -111,7 +111,7 @@ class get_EO_analysis_files():
 
         else:
             if 'RTM' in device:
-                ccd_list = self.eR.raftContents(raftName=device, when=when)
+                ccd_list = self.dev_prod.app_map["exploreRaft"][db].raftContents(raftName=device, when=when)
                 for ccd in ccd_list:
                     dev_list.append(ccd)
             else:
@@ -119,7 +119,7 @@ class get_EO_analysis_files():
                 self.slot_or_ccd = 'ccd'
 
             for ccd in dev_list:
-                filelist = self.fCCD.find(mirrorName=mirrorName, FType=FType,
+                filelist = self.dev_prod.app_map["findCCD"][db].find(mirrorName=mirrorName, FType=FType,
                                           XtraOpts=imgtype, run=run,
                                           testName=testName, sensorId=ccd[0])
                 matchlist = []
@@ -136,6 +136,7 @@ class get_EO_analysis_files():
         """
         deduce_mirror: Given the run number, figure out which Data Catalog mirror its data is registered in
         """
+
         mirrorName = 'INT-prod'
 
         if "Integration" in self.run_sum['subsystem']:

--- a/python/get_EO_analysis_files.py
+++ b/python/get_EO_analysis_files.py
@@ -125,7 +125,7 @@ class get_EO_analysis_files():
                 matchlist = []
                 for f in filelist:
                     if matchstr is not None:
-                        if f.find(matchstr) < 0:
+                        if f.find(matchstr) < 0 or f.find(ccd[0]) < 0:
                             continue
                     matchlist.append(f)
                 ccd_dict[ccd[idx]] = matchlist

--- a/python/get_EO_analysis_results.py
+++ b/python/get_EO_analysis_results.py
@@ -232,6 +232,10 @@ class get_EO_analysis_results():
         """
 
         dev_list = []
+        if run is not None:
+            db = self.dev_prod.set_db(run=run)
+
+        eT_conn = self.dev_prod.use_app("Connection", db)
 
         if run is None:
 
@@ -244,7 +248,6 @@ class get_EO_analysis_results():
             else:
                 self.camera_type = 'ts3'
 
-            eT_conn = self.dev_prod.use_app("Connection", db)
             data = eT_conn.getResultsJH(htype=self.site_type[site_type][0],
                                         stepName=self.type_dict[self.camera_type][test_type][0],
                                         travelerName=self.site_type[site_type][1])
@@ -312,6 +315,17 @@ class get_EO_analysis_results():
                 c = ccd_dict.setdefault(ccdName, [])
                 ampResult = amp[test_type]
                 c.append(ampResult)
+
+            # patch for CR single raft test results - WREB results duplicated under WREB0
+            try:
+                wreb = ccd_dict["WREB0"]
+                wreb0_patch = wreb[0:8]
+                wreb1_patch = wreb[9:17]
+                ccd_dict["WREB0"] = wreb0_patch
+                ccd_dict["WREB1"] = wreb1_patch
+            except KeyError:
+                pass
+
             return ccd_dict
 
         else:
@@ -389,6 +403,17 @@ class get_EO_analysis_results():
                     c = t.setdefault(ccdName, [])
                     ampResult = amp[tests]
                     c.append(ampResult)
+
+                # patch for CR single raft test results - WREB results duplicated under WREB0
+                try:
+                    wreb = t["WREB0"]
+                    wreb0_patch = wreb[0:8]
+                    wreb1_patch = wreb[9:17]
+                    t["WREB0"] = wreb0_patch
+                    t["WREB1"] = wreb1_patch
+                except KeyError:
+                    pass
+
 
         else:
             for step in data["steps"]:

--- a/python/get_EO_analysis_results.py
+++ b/python/get_EO_analysis_results.py
@@ -483,6 +483,7 @@ if __name__ == "__main__":
     parser.add_argument('-s', '--site_type', default='I&T-Raft', help="type & site of test (default=%("
                                                                       "default)s)")
     parser.add_argument('-r', '--run', default=None, help="run number (default=%(default)s)")
+    parser.add_argument('-p', '--print', default=None, help="print (default=%(default)s)")
     args = parser.parse_args()
 
     g = get_EO_analysis_results(db=args.db, server=args.eTserver)
@@ -493,6 +494,10 @@ if __name__ == "__main__":
         raft_list, data = g.get_tests(site_type=args.site_type, test_type=args.test_type, run=args.run)
         res = g.get_results(test_type=args.test_type, data=data, device=raft_list)
         after_sngl = time.time() - start
+
+        if args.print is not None and args.run is not None:
+            print(args.test_type + " values for run ", args.run)
+            print (res)
 
         raft_list_all, data_all = g.get_tests(site_type=args.site_type, run=args.run)
         res_all = g.get_all_results(data=data_all, device=raft_list_all)

--- a/python/get_EO_analysis_results.py
+++ b/python/get_EO_analysis_results.py
@@ -246,8 +246,8 @@ class get_EO_analysis_results():
 
             eT_conn = self.dev_prod.use_app("Connection", db)
             data = eT_conn.getResultsJH(htype=self.site_type[site_type][0],
-                                             stepName=self.type_dict[self.camera_type][test_type][0],
-                                             travelerName=self.site_type[site_type][1])
+                                        stepName=self.type_dict[self.camera_type][test_type][0],
+                                        travelerName=self.site_type[site_type][1])
             # Get a list of devices
             for dev in data:
                 dev_list.append(dev)
@@ -264,8 +264,7 @@ class get_EO_analysis_results():
                 data = eT_conn.getRunResults(run=run, stepName=stepName)
             if self.camera_type == "BOT":
                 rl = self.dev_prod.app_map["exploreFocalPlane"][db].focalPlaneContents(
-                    parentName=self.site_type[
-                    "I&T-BOT"][0], run=run)
+                    parentName=self.site_type["I&T-BOT"][0], run=run)
                 for r in rl:
                     dev_list.append(r[0])
             else:

--- a/python/get_EO_analysis_results.py
+++ b/python/get_EO_analysis_results.py
@@ -428,7 +428,7 @@ class get_EO_analysis_results():
 
         run_sum = self.dev_prod.app_map["Connection"][db].getRunSummary(run=run)
 
-        if "CRYO" in run_sum['experimentSN']:
+        if "CRYO" in run_sum['experimentSN'].upper():
             siteName = "BOT"
             self.camera_type = siteName
         elif run_sum['travelerName'] == "SR-EOT-02":

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -1,0 +1,7 @@
+import unittest
+
+runner = unittest.TextTestRunner()
+
+loader = unittest.TestLoader()
+testsuite = loader.discover('.', pattern='test_*.py')
+runner.run(testsuite)

--- a/tests/test_exploreRaft.py
+++ b/tests/test_exploreRaft.py
@@ -10,12 +10,12 @@ class TestExploreRaft(TestCase):
 
         ccd_list = eR.raftContents(raftName)
 
-        assert (ccd_list[0][0] == 'ITL-3800C-381'), "Failed CCD id"
+        assert (ccd_list[0][0] == 'ITL-3800C-372'), "Failed CCD id"
 
     def test_CCD_parent(self):
         eR = exploreRaft()
 
-        CCD_name = "ITL-3800C-381"
+        CCD_name = "ITL-3800C-372"
 
         parentRaft = eR.CCD_parent(CCD_name, 'ITL-CCD')
 
@@ -24,7 +24,7 @@ class TestExploreRaft(TestCase):
     def test_REB_parent(self):
         eR = exploreRaft()
 
-        assert (eR.REB_parent("LCA-13574-064") == "LCA-11021_RTM-004"), "failed REB parent id"
+        assert (eR.REB_parent("LCA-13574-069") == "LCA-11021_RTM-004"), "failed REB parent id"
 
     def test_REB_CCD(self):
         eR = exploreRaft()

--- a/tests/test_exploreRaft.py
+++ b/tests/test_exploreRaft.py
@@ -24,10 +24,10 @@ class TestExploreRaft(TestCase):
     def test_REB_parent(self):
         eR = exploreRaft()
 
-        assert (eR.REB_parent("LCA-13574-069") == "LCA-11021_RTM-004"), "failed REB parent id"
+        assert (eR.REB_parent("LCA-13574-031") == "LCA-11021_RTM-004"), "failed REB parent id"
 
     def test_REB_CCD(self):
         eR = exploreRaft()
 
-        reb_ccds = eR.REB_CCD('LCA-13574-064')
-        assert (reb_ccds[0] == "ITL-3800C-381"), "Failed Raft CCD content id"
+        reb_ccds = eR.REB_CCD('LCA-13574-031')
+        assert (reb_ccds[0] == "ITL-3800C-372"), "Failed Raft CCD content id"


### PR DESCRIPTION
Some travelers store all the files in the same directory, so findCCD finds all CCD's files every time it queries for one. Fix is to require CCD name in the file spec as well. It had worked fine for bright_pixels, but dark pixels was organized differently (for example).