### PR TITLE
Added other PTC fit quantities for TS8 data

### DIFF
--- a/python/get_EO_analysis_results.py
+++ b/python/get_EO_analysis_results.py
@@ -141,6 +141,10 @@ class get_EO_analysis_results():
         self.type_dict_raft['dark_current_95CL'] = ['dark_current_raft', 'dark_current_raft']
         self.type_dict_raft['ptc_gain'] = ['ptc_raft', 'ptc_raft']
         self.type_dict_raft['ptc_gain_error'] = ['ptc_raft', 'ptc_raft']
+        self.type_dict_raft['ptc_a00'] = ['ptc_raft', 'ptc_raft']
+        self.type_dict_raft['ptc_a00_error'] = ['ptc_raft', 'ptc_raft']
+        self.type_dict_raft['ptc_noise'] = ['ptc_raft', 'ptc_raft']
+        self.type_dict_raft['ptc_noise_error'] = ['ptc_raft', 'ptc_raft']
 
         self.type_dict_raft['QE'] = ['qe_raft_analysis', 'qe_raft_analysis']
         self.type_dict_raft['full_well'] = ['flat_pairs_raft_analysis', 'flat_pairs_raft']


### PR DESCRIPTION
This adds four quantities from the PTC fits from the ptc_raft step of TS8 eTraveler runs, so get_EO_analysis_results.py will retrieve them.