### PR TITLE
U/digel/allow tearing

### DIFF
--- a/python/get_EO_analysis_results.py
+++ b/python/get_EO_analysis_results.py
@@ -432,11 +432,11 @@ class get_EO_analysis_results():
             for tests in test_list:
                 step = test_list[tests][0]
 
-                if step == "tearing_BOT":  # no per-amp quantities here
-                    continue
-
                 test_name_type = test_list[tests][1]
                 t_dict = data['steps'][step]
+                if step == "tearing_BOT":  # drop tearing_detections_BOT, which is per sensor
+                    if 'tearing_detections_BOT' in t_dict.keys():
+                        del t_dict['tearing_detections_BOT']
 
                 for a in t_dict[test_name_type][1:]:
                     try:

--- a/python/get_EO_analysis_results.py
+++ b/python/get_EO_analysis_results.py
@@ -433,43 +433,44 @@ class get_EO_analysis_results():
                 step = test_list[tests][0]
 
                 test_name_type = test_list[tests][1]
-                t_dict = data['steps'][step]
-                if step == "tearing_BOT":  # drop tearing_detections_BOT, which is per sensor
-                    if 'tearing_detections_BOT' in t_dict.keys():
-                        del t_dict['tearing_detections_BOT']
+                if test_name_type != 'tearing_detection_BOT':
+                    t_dict = data['steps'][step]
+                    if step == "tearing_BOT":  # drop tearing_detections_BOT, which is per sensor
+                        if 'tearing_detection_BOT' in t_dict.keys():
+                            del t_dict['tearing_detection_BOT']
 
-                for a in t_dict[test_name_type][1:]:
-                    try:
-                        raft_slot = a["raft"]
-                        ccd_slot = a["slot"]
-                    except KeyError:
-                        try:  # some tests combine raft and slot into sensor_id
-                            s_id = a["sensor_id"]
-                            s_id_str = s_id.split("_")
-                            raft_slot = s_id_str[0]
-                            ccd_slot = s_id_str[1]
+                    for a in t_dict[test_name_type][1:]:
+                        try:
+                            raft_slot = a["raft"]
+                            ccd_slot = a["slot"]
                         except KeyError:
-                            print(a)
+                            try:  # some tests combine raft and slot into sensor_id
+                                s_id = a["sensor_id"]
+                                s_id_str = s_id.split("_")
+                                raft_slot = s_id_str[0]
+                                ccd_slot = s_id_str[1]
+                            except KeyError:
+                                print(a)
 
-                    res = tests
-                    #for res in self.BOT_schema_meas[test_name_type]:
-                    try:
-                        meas = a[res]
-                        #meas = a[tests]
-                    except KeyError:
-                        break
+                        res = tests
+                        #for res in self.BOT_schema_meas[test_name_type]:
+                        try:
+                            meas = a[res]
+                            #meas = a[tests]
+                        except KeyError:
+                            break
 
-                    if res == "QE":
-                        band = a["band"]
-                        qe_band = res + "-" + str(band)
-                        t = test_dict.setdefault(qe_band, {})
-                    else:
-                        t = test_dict.setdefault(res, {})
-                    r = t.setdefault(raft_slot, {})
-                    c = r.setdefault(ccd_slot, copy.copy(test_array))
+                        if res == "QE":
+                            band = a["band"]
+                            qe_band = res + "-" + str(band)
+                            t = test_dict.setdefault(qe_band, {})
+                        else:
+                            t = test_dict.setdefault(res, {})
+                        r = t.setdefault(raft_slot, {})
+                        c = r.setdefault(ccd_slot, copy.copy(test_array))
 
-                    amp_id = a["amp"] - 1
-                    c[amp_id] = meas
+                        amp_id = a["amp"] - 1
+                        c[amp_id] = meas
 
         return test_dict
 

--- a/python/get_steps_schema.py
+++ b/python/get_steps_schema.py
@@ -54,7 +54,7 @@ class get_steps_schema:
                 test_list = schema_list[schema][0]
                 for item in test_list:
                     if 'amp' in item or "slot" in item or "raft" in item or "sensor" in item \
-                            or "schema" in item or "job" in item or "detections" in item or \
+                            or "schema" in item or "job" in item or \
                             "subset" in item or "file" in item or "host" in item or "wavelength" in item:
                         continue
 


### PR DESCRIPTION
This modification allows get_EO_analysis_results to retrieve divisidero_max_dev and tearing_stats quantities from the tearing_BOT step.  The tearing_detection_BOT quantities from that step are ignored.  They are per-sensor quantities (rather than per-amp) that were calculated for some runs.